### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ JenkinsCI-iOS
 
 A Jenkins job setup for your XCode project.
 
-##Contents: <br/>
+## Contents: <br/>
 [Installing Jenkins](#installing-jenkins)<br />
 [XCode project setup](#xcode-project-setup)<br />
 [Jenkins plugins](#jenkins-plugins)<br />


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
